### PR TITLE
Razor active search fix

### DIFF
--- a/CSharp/RazorPages/Helpers/SseHelper.cs
+++ b/CSharp/RazorPages/Helpers/SseHelper.cs
@@ -8,7 +8,10 @@ public static class SseHelper
     {
         response.Headers.Append("Cache-Control", "no-cache");
         response.Headers.Append("Content-Type", "text/event-stream");
-        response.Headers.Append("Connection", "keep-alive");
+
+        // HTTP/2.0 and later do not require the Connection: keep-alive header
+        //response.Headers.Append("Connection", "keep-alive");
+
         await response.Body.FlushAsync();
     }
 

--- a/CSharp/RazorPages/Program.cs
+++ b/CSharp/RazorPages/Program.cs
@@ -14,6 +14,8 @@ if (!app.Environment.IsDevelopment())
 }
 
 
+app.UseHttpsRedirection();
+
 app.Use(async (context, next) => {
 
     // is this a datastar request? Datastar-Request: true
@@ -23,6 +25,9 @@ app.Use(async (context, next) => {
     if (isDatastarRequest)
     {
         // TODO: parse the datastar payload and put it in context.Items as a simple, immutable, dictionary
+
+        // We need to write the response for the datastar request here and then not call next.Invoke().
+        // In order to do that, we need to know how to route the request or switch to a command handler pattern.
     }
 
     // The call to next.Invoke() triggers an exception that headers are being written but the response body has already started.
@@ -33,14 +38,15 @@ app.Use(async (context, next) => {
     }
     catch (InvalidOperationException ex)
     {
+        // NOTE: Even though this exception is thrown, the response to the datastar request has already been sent. 
+
         // Log the exception or handle it as needed
         Console.WriteLine("Caught an InvalidOperationException: " + ex.Message);
     }
 });
 
-app.UseHttpsRedirection();
 app.UseRouting();
-//app.UseAuthorization();
+app.UseAuthorization();
 
 
 app.MapStaticAssets();

--- a/CSharp/RazorPages/Program.cs
+++ b/CSharp/RazorPages/Program.cs
@@ -13,9 +13,35 @@ if (!app.Environment.IsDevelopment())
     app.UseHsts();
 }
 
+
+app.Use(async (context, next) => {
+
+    // is this a datastar request? Datastar-Request: true
+    var isDatastarRequest = context.Request.Headers.TryGetValue("Datastar-Request", out var headerValue)
+        && string.Equals(headerValue, "true", StringComparison.OrdinalIgnoreCase);
+
+    if (isDatastarRequest)
+    {
+        // TODO: parse the datastar payload and put it in context.Items as a simple, immutable, dictionary
+    }
+
+    // The call to next.Invoke() triggers an exception that headers are being written but the response body has already started.
+    // A custom exception handler middleware could be used to handle this more gracefully, but it would be nice to know what is causing this.
+    try
+    {
+        await next.Invoke();
+    }
+    catch (InvalidOperationException ex)
+    {
+        // Log the exception or handle it as needed
+        Console.WriteLine("Caught an InvalidOperationException: " + ex.Message);
+    }
+});
+
 app.UseHttpsRedirection();
 app.UseRouting();
-app.UseAuthorization();
+//app.UseAuthorization();
+
 
 app.MapStaticAssets();
 app.MapRazorPages()


### PR DESCRIPTION
I got Active Search working by getting the datastar request payload from the query string rather than body. 

The bigger issue is with the razor pipeline. It's trying to set some headers after the response to the datastar request is complete and that is throwing an InvalidOperationException. I think it's because the page handlers are trying to re-render the whole page and therefore shouldn't really be used in this scenario. I added some comments in the inline middleware I added to Program.cs about this. For now, the exception is captured and then logged to output as it doesn't affect behavior. 